### PR TITLE
pass testdb as arg

### DIFF
--- a/server/src/test.ts
+++ b/server/src/test.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-import type { Context, Env } from './types';
+import type { Env } from './types';
 
 export const testRoute = new Hono<{ Bindings: Env }>()
   .post('/reset', async (c) => {
@@ -8,15 +8,15 @@ export const testRoute = new Hono<{ Bindings: Env }>()
       console.warn(`cannot reset db in env: ${c.env.ENV}`);
       throw new HTTPException(404, { message: 'Not Found' });
     }
-    await resetDb(c);
+    // explicitly use c.env.TEST_DB and not getDb() to be sure we are only
+    // adjusting the local test db binding
+    await resetDb(c.env.TEST_DB);
     return new Response('ok', { status: 200 });
   })
   .notFound(() => {
     throw new HTTPException(404, { message: 'Not Found' });
   });
 
-/** Explicitly use c.env.TEST_DB and not getDb() to be sure we are only
- * adjusting the local test db binding */
-const resetDb = async (c: Context) => {
-  await c.env.TEST_DB.delete('highScore');
+const resetDb = async (testDb: KVNamespace) => {
+  await testDb.delete('highScore');
 };

--- a/server/src/test.ts
+++ b/server/src/test.ts
@@ -17,6 +17,6 @@ export const testRoute = new Hono<{ Bindings: Env }>()
     throw new HTTPException(404, { message: 'Not Found' });
   });
 
-const resetDb = async (testDb: KVNamespace) => {
+const resetDb = async (testDb: Env['TEST_DB']) => {
   await testDb.delete('highScore');
 };


### PR DESCRIPTION
Doing this so devs only have to edit `resetDb` and not make the mistake of passing the wrong binding.